### PR TITLE
Radius changes

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -57,6 +57,7 @@ fn spawn_camera(mut commands: Commands) {
                 // typical logistic function centered at 0.5
                 lower_displacement_function: |x| 1. / (1. + E.powf(-15. * (x - 0.5))),
                 upper_displacement_function: |x| 1. / (1. + E.powf(-15. * (x - 0.5))),
+                behind_radius_displacement: 2.0,
             },
             ..default()
         },

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -53,11 +53,12 @@ fn spawn_camera(mut commands: Commands) {
                 lower_threshold: PI / 2.,
                 upper_threshold: 2. * PI / 3.,
                 max_forward_displacement: 0.5,
-                max_backward_displacement: 0.5,
+                max_backward_displacement: 0.75,
                 // typical logistic function centered at 0.5
                 lower_displacement_function: |x| 1. / (1. + E.powf(-15. * (x - 0.5))),
                 upper_displacement_function: |x| 1. / (1. + E.powf(-15. * (x - 0.5))),
                 behind_radius_displacement: 2.0,
+                lower_radius_function: |x| 1. - E.powf(-4. * x),
             },
             ..default()
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ pub struct CameraFocusModifier {
     pub upper_displacement_function: fn(f32) -> f32,
     /// Must clasp the values between 0 and 1
     pub lower_displacement_function: fn(f32) -> f32,
+    pub behind_radius_displacement: f32,
 }
 
 impl Default for CameraFocusModifier {
@@ -129,6 +130,7 @@ impl Default for CameraFocusModifier {
             lower_threshold: 0.,
             upper_displacement_function: |_a| 0.,
             lower_displacement_function: |_a| 0.,
+            behind_radius_displacement: 0.,
         }
     }
 }
@@ -195,7 +197,13 @@ pub fn modify_focus(mut cam_q: Query<(&mut ThirdPersonCamera, &Transform)>) {
             cam.true_focus.z + xz.y,
         )
             .into();
+        // move the camera closer to the focus when looking upwards
+        let radius_change = focus_disp * -cam.focus_modifier.behind_radius_displacement;
+        cam.zoom.radius = cam.zoom.true_radius + radius_change;
     } else {
+        if let Some(rad) = cam.zoom.radius_copy {
+            cam.zoom.radius = rad;
+        }
         cam.focus = cam.true_focus;
     }
     // info!("Center Focus: {}", cam.true_focus);
@@ -208,6 +216,7 @@ pub struct Zoom {
     pub min: f32,
     pub max: f32,
     radius: f32,
+    true_radius: f32,
     radius_copy: Option<f32>,
 }
 
@@ -217,6 +226,7 @@ impl Zoom {
             min,
             max,
             radius: (min + max) / 2.0,
+            true_radius: (min + max) / 2.0,
             radius_copy: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,10 @@ pub struct CameraFocusModifier {
     pub upper_displacement_function: fn(f32) -> f32,
     /// Must clasp the values between 0 and 1
     pub lower_displacement_function: fn(f32) -> f32,
+    /// Determines the amount to shrink the camera zoom radius by when looking upwards
     pub behind_radius_displacement: f32,
+    /// Must clasp the values between 0 and 1
+    pub lower_radius_function: fn(f32) -> f32,
 }
 
 impl Default for CameraFocusModifier {
@@ -131,6 +134,7 @@ impl Default for CameraFocusModifier {
             upper_displacement_function: |_a| 0.,
             lower_displacement_function: |_a| 0.,
             behind_radius_displacement: 0.,
+            lower_radius_function: |_a| 0.,
         }
     }
 }
@@ -185,9 +189,9 @@ pub fn modify_focus(mut cam_q: Query<(&mut ThirdPersonCamera, &Transform)>) {
         let theta =
             (angle - cam.focus_modifier.lower_threshold) / -cam.focus_modifier.lower_threshold;
         // focus_disp is bound between 0 - 1 (close enough again)
-        let focus_disp = (cam.focus_modifier.upper_displacement_function)(theta);
+        let focus_disp = (cam.focus_modifier.lower_radius_function)(theta);
         // actual change in the xz direction, ranges from 0 - max_forward_displacement
-        let displacement = focus_disp * cam.focus_modifier.max_forward_displacement;
+        let displacement = focus_disp * cam.focus_modifier.max_backward_displacement;
         // move the focus "forward" by focus_disp
         let xz = transform.back().xz().normalize() * displacement;
         // updates the focus to be the true focus plus the displacement found before
@@ -201,9 +205,6 @@ pub fn modify_focus(mut cam_q: Query<(&mut ThirdPersonCamera, &Transform)>) {
         let radius_change = focus_disp * -cam.focus_modifier.behind_radius_displacement;
         cam.zoom.radius = cam.zoom.true_radius + radius_change;
     } else {
-        if let Some(rad) = cam.zoom.radius_copy {
-            cam.zoom.radius = rad;
-        }
         cam.focus = cam.true_focus;
     }
     // info!("Center Focus: {}", cam.true_focus);


### PR DESCRIPTION
This implements a generally complete (doesn't account for collision) way to change the radius of the camera when the camera goes below the lower threshold.

This means that not only will the camera change its focus to be "behind" the character, but also get closer to said focus to see more of the area above and around the player.